### PR TITLE
Proposal: post-backup-script option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Container images are configured using environment variables passed at runtime.
  * `PRUNE_CRON`              - Set schedule for `duplicacy prune` command in format for crontab file. The `duplicacy prune` command doesn't run if `PRUNE_CRON` is not set.
  * `GLOBAL_OPTIONS`          - Set global options for every `duplicacy` command, see ["Global options details"][duplicacy-global-options] for details. Global options are not set by default.
  * `BACKUP_OPTIONS`          - Set options for every `duplicacy backup` command, see `duplicacy backup` command [description][duplicacy-backup] for details. Backup options are not set by default.
+ * `POST_BACKUP_SCRIPT'      - Give path of a custom script to run once backup completes
  * `PRUNE_OPTIONS`           - Set options for every `duplicacy prune` command, see `duplicacy prune` command [description][duplicacy-prune] for details. Prune options are not set by default.
  * `RUN_JOB_IMMEDIATELY`     - Set to `yes` to run `duplicacy backup` and/or `duplicacy prune` command at container startup. Immeditely jobs don't start by default.
  * `SNAPSHOT_ID`             - Set snapshot id, see `duplicacy init` command [description][duplicacy-init] for details.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Container images are configured using environment variables passed at runtime.
  * `PRUNE_CRON`              - Set schedule for `duplicacy prune` command in format for crontab file. The `duplicacy prune` command doesn't run if `PRUNE_CRON` is not set.
  * `GLOBAL_OPTIONS`          - Set global options for every `duplicacy` command, see ["Global options details"][duplicacy-global-options] for details. Global options are not set by default.
  * `BACKUP_OPTIONS`          - Set options for every `duplicacy backup` command, see `duplicacy backup` command [description][duplicacy-backup] for details. Backup options are not set by default.
- * `POST_BACKUP_SCRIPT'      - Give path of a custom script to run once backup completes
+ * `POST_BACKUP_SCRIPT`      - Give path of a custom script to run once backup completes
  * `PRUNE_OPTIONS`           - Set options for every `duplicacy prune` command, see `duplicacy prune` command [description][duplicacy-prune] for details. Prune options are not set by default.
  * `RUN_JOB_IMMEDIATELY`     - Set to `yes` to run `duplicacy backup` and/or `duplicacy prune` command at container startup. Immeditely jobs don't start by default.
  * `SNAPSHOT_ID`             - Set snapshot id, see `duplicacy init` command [description][duplicacy-init] for details.

--- a/root/app/backup.sh
+++ b/root/app/backup.sh
@@ -36,6 +36,15 @@ else
     subject="duplicacy backup job id \"$hostname:$SNAPSHOT_ID\" FAILED"
 fi
 
+if [ -n $POST_BACKUP_SCRIPT ] ; then
+	if [ -e $POST_BACKUP_SCRIPT ] ; then
+		export log_file exitcode duration my_dir # Variables I require in my post backup script
+		sh -c ${POST_BACKUP_SCRIPT}
+	else
+		echo POST_BACKUP_SCRIPT not found
+	fi
+fi
+
 "$my_dir/mailto.sh" $log_dir "$subject"
 
 exit $exitcode


### PR DESCRIPTION
Hi,

Here is my proposal for adding a POST_BACKUP_SCRIPT environment variable to be executed after a backup has occurred.

In my particular case I like to do some post-backup actions such as listing all files in the last revision in a log file, keeping the backup log on disk, keeping a list of all revisions in a separate log, etc, the post-backup-hook enables this that not everybody might want to do and which probably will make the list of environment variables too long otherwise.
