### PR TITLE
Proposal: POST_PRUNE_SCRIPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Container images are configured using environment variables passed at runtime.
  * `BACKUP_OPTIONS`          - Set options for every `duplicacy backup` command, see `duplicacy backup` command [description][duplicacy-backup] for details. Backup options are not set by default.
  * `POST_BACKUP_SCRIPT`      - Give path of a custom script to run once backup completes.
  * `PRUNE_OPTIONS`           - Set options for every `duplicacy prune` command, see `duplicacy prune` command [description][duplicacy-prune] for details. Prune options are not set by default.
+ * `POST_PRUNE_SCRIPT`       - Give path of a custom script to run once prune completes.
  * `RUN_JOB_IMMEDIATELY`     - Set to `yes` to run `duplicacy backup` and/or `duplicacy prune` command at container startup. Immeditely jobs don't start by default.
  * `SNAPSHOT_ID`             - Set snapshot id, see `duplicacy init` command [description][duplicacy-init] for details.
  * `STORAGE_URL`             - Set storage url, see `duplicacy init` command [description][duplicacy-init] for details. Duplicacy supports different storage providers, see ["Supported storage backends"][duplicacy-storage] for details. Login credentials for storage url should be set using environment variables, see ["Passwords, credentials and environment variables"][duplicacy-variables] for details.

--- a/root/app/prune.sh
+++ b/root/app/prune.sh
@@ -43,6 +43,15 @@ else
     subject="duplicacy prune job id \"$hostname:$SNAPSHOT_ID\" FAILED"
 fi
 
+if [ -n $POST_PRUNE_SCRIPT ] ; then
+    if [ -e $POST_PRUNE_SCRIPT ] ; then
+        export log_file exitcode duration my_dir # Variables I require in my post prune script
+        sh -c ${POST_PRUNE_SCRIPT}
+    else
+        echo POST_PRUNE_SCRIPT not found
+    fi
+fi
+
 "$my_dir/mailto.sh" $log_dir "$subject"
 
 exit $exitcode


### PR DESCRIPTION
Thanks for implementing POST_BACKUP_SCRIPT !

Last one for the time being - and much the same as POST_BACKUP_SCRIPT, this runs during prune.sh and whilst the log, exitcode, etc. is available.

Here's a similar example of using such a script:

```
#!/bin/bash
#

source /scripts/pushover-functions.sh
source $my_dir/common.sh # for 'converts'

# Keep a prune log
cat $log_file >> /log/prune.log

# Pushover notification 
if [ -n ${PUSHOVER_USERKEY} ] ; then
        if [ $exitcode = 0 ] ; then 
                status=OK
        else
                status=ERROR
        fi
        pushover-send "${HOSTNAME} prune $status duration $(converts $duration)"
fi
```
No tabs in this merge request, apologies!

Totally aside (as this example script is not just for !Email notification). 

If there is any interest I can add my (really one-liner) _pushover-functions.sh_ into _common.sh_ and document using notifications with Pushover. My only doubt about it is that there is a ton of messaging bus-type apps out there and I'm unsure if anybody else would find it useful.



