### PR TITLE
Proposal: BACKUP_END_CRON

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Container images are configured using environment variables passed at runtime.
 
  * `BACKUP_CRON`             - Set schedule for `duplicacy backup` command in format for crontab file. The `duplicacy backup` command doesn't run if `BACKUP_CRON` is not set.
  * `PRUNE_CRON`              - Set schedule for `duplicacy prune` command in format for crontab file. The `duplicacy prune` command doesn't run if `PRUNE_CRON` is not set.
+ * `BACKUP_END_CRON`         - Set schedule for force killing of duplicacy backup process in format for crontab file. The force killing of duplicacy backup process doesn't run if `BACKUP_END_CRON` is not set.
  * `PRIORITY_LEVEL`          - Run `duplicacy` with an adjusted niceness, which affects process scheduling. Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process). Default value is 10.
  * `GLOBAL_OPTIONS`          - Set global options for every `duplicacy` command, see ["Global options details"][duplicacy-global-options] for details. Global options are not set by default.
  * `BACKUP_OPTIONS`          - Set options for every `duplicacy backup` command, see `duplicacy backup` command [description][duplicacy-backup] for details. Backup options are not set by default.

--- a/root/app/end_backup.sh
+++ b/root/app/end_backup.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/with-contenv bash
+pid=$(ps | grep "duplicacy backup" | grep -v "grep" | cut -d " " -f 1)
+kill -2 $dup_pid
+exit 0

--- a/root/etc/cont-init.d/60-createcron
+++ b/root/etc/cont-init.d/60-createcron
@@ -14,4 +14,8 @@ if [[ "${PRUNE_CRON}" ]]; then
     echo "$PRUNE_CRON /app/prune.sh" >> $cron_file
 fi
 
+if [[ "${BACKUP_END_CRON}" ]]; then
+    echo "$BACKUP_END_CRON /app/end_backup.sh" >> $cron_file
+fi
+
 exit 0


### PR DESCRIPTION
Hi,

Here is my proposal for adding a BACKUP_END_CRON environment variable to be executed on CRON schedule.

My need is that I have a limited window for backing up and needed a way for end the current backup.
This uses the kill -2 (or Ctrl-C) which tells duplicacy to write the incomplete file before exiting allowing the backup to resume with current uploaded progress.