### PR TITLE
Add the capability to run a pre-backup script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Container images are configured using environment variables passed at runtime.
  * `PRIORITY_LEVEL`          - Run `duplicacy` with an adjusted niceness, which affects process scheduling. Niceness values range from -20 (most favorable to the process) to 19 (least favorable to the process). Default value is 10.
  * `GLOBAL_OPTIONS`          - Set global options for every `duplicacy` command, see ["Global options details"][duplicacy-global-options] for details. Global options are not set by default.
  * `BACKUP_OPTIONS`          - Set options for every `duplicacy backup` command, see `duplicacy backup` command [description][duplicacy-backup] for details. Backup options are not set by default.
+ * `PRE_BACKUP_SCRIPT`       - Give path of a custom script to run just before a backup starts.
  * `POST_BACKUP_SCRIPT`      - Give path of a custom script to run once backup completes.
  * `PRUNE_OPTIONS`           - Set options for every `duplicacy prune` command, see `duplicacy prune` command [description][duplicacy-prune] for details. Prune options are not set by default.
  * `POST_PRUNE_SCRIPT`       - Give path of a custom script to run once prune completes.

--- a/root/app/backup.sh
+++ b/root/app/backup.sh
@@ -22,7 +22,7 @@ if [[ ! -z ${PRE_BACKUP_SCRIPT} ]]; then
         echo Run pre backup script | tee -a $log_file
         export log_file my_dir # Variables I require in my pre backup script
         sh -c "${PRE_BACKUP_SCRIPT}"
-        exitcode = ${PIPESTATUS[0]
+        exitcode = ${PIPESTATUS[0]}
     else
         echo Pre backup script defined, but file not found | tee -a $log_file
         # Command not found exit code (https://tldp.org/LDP/abs/html/exitcodes.html)

--- a/root/app/backup.sh
+++ b/root/app/backup.sh
@@ -22,38 +22,45 @@ if [[ ! -z ${PRE_BACKUP_SCRIPT} ]]; then
         echo Run pre backup script | tee -a $log_file
         export log_file my_dir # Variables I require in my pre backup script
         sh -c "${PRE_BACKUP_SCRIPT}"
+        exitcode = ${PIPESTATUS[0]
     else
         echo Pre backup script defined, but file not found | tee -a $log_file
+        # Command not found exit code (https://tldp.org/LDP/abs/html/exitcodes.html)
+        exitcode = 127
     fi
 fi
-
-start=$(date +%s.%N)
-config_dir=/config
-
-cd $config_dir
-
-nice -n $PRIORITY_LEVEL duplicacy $GLOBAL_OPTIONS backup $BACKUP_OPTIONS | tee -a $log_file
-exitcode=${PIPESTATUS[0]}
-
-duration=$(echo "$(date +%s.%N) - $start" | bc)
-subject=""
 
 if [ $exitcode -eq 0 ]; then
-    echo Backup COMPLETED, duration $(converts $duration) | tee -a $log_file
-    subject="duplicacy backup job id \"$hostname:$SNAPSHOT_ID\" COMPLETED"
-else
-    echo Backup FAILED, code $exitcode, duration $(converts $duration) | tee -a $log_file
-    subject="duplicacy backup job id \"$hostname:$SNAPSHOT_ID\" FAILED"
-fi
+    start=$(date +%s.%N)
+    config_dir=/config
 
-if [[ ! -z ${POST_BACKUP_SCRIPT} ]]; then
-    if [[ -f ${POST_BACKUP_SCRIPT} ]]; then
-        echo Run post backup script | tee -a $log_file
-        export log_file exitcode duration my_dir # Variables I require in my post backup script
-        sh -c "${POST_BACKUP_SCRIPT}"
+    cd $config_dir
+
+    nice -n $PRIORITY_LEVEL duplicacy $GLOBAL_OPTIONS backup $BACKUP_OPTIONS | tee -a $log_file
+    exitcode=${PIPESTATUS[0]}
+
+    duration=$(echo "$(date +%s.%N) - $start" | bc)
+    subject=""
+
+    if [ $exitcode -eq 0 ]; then
+        echo Backup COMPLETED, duration $(converts $duration) | tee -a $log_file
+        subject="duplicacy backup job id \"$hostname:$SNAPSHOT_ID\" COMPLETED"
     else
-        echo Post backup script defined, but file not found | tee -a $log_file
+        echo Backup FAILED, code $exitcode, duration $(converts $duration) | tee -a $log_file
+        subject="duplicacy backup job id \"$hostname:$SNAPSHOT_ID\" FAILED"
     fi
+
+    if [[ ! -z ${POST_BACKUP_SCRIPT} ]]; then
+        if [[ -f ${POST_BACKUP_SCRIPT} ]]; then
+            echo Run post backup script | tee -a $log_file
+            export log_file exitcode duration my_dir # Variables I require in my post backup script
+            sh -c "${POST_BACKUP_SCRIPT}"
+        else
+            echo Post backup script defined, but file not found | tee -a $log_file
+        fi
+    fi
+else
+    echo Pre backup script FAILED, code $exitcode, | tee -a $log_file
 fi
 
 "$my_dir/mailto.sh" $log_dir "$subject"

--- a/root/app/backup.sh
+++ b/root/app/backup.sh
@@ -17,6 +17,16 @@ echo ========== Run backup job at `date` ========== | tee $log_file
 
 "$my_dir/delay.sh" $log_file
 
+if [[ ! -z ${PRE_BACKUP_SCRIPT} ]]; then
+    if [[ -f ${PRE_BACKUP_SCRIPT} ]]; then
+        echo Run pre backup script | tee -a $log_file
+        export log_file my_dir # Variables I require in my pre backup script
+        sh -c "${PRE_BACKUP_SCRIPT}"
+    else
+        echo Pre backup script defined, but file not found | tee -a $log_file
+    fi
+fi
+
 start=$(date +%s.%N)
 config_dir=/config
 

--- a/root/app/backup.sh
+++ b/root/app/backup.sh
@@ -22,11 +22,11 @@ if [[ ! -z ${PRE_BACKUP_SCRIPT} ]]; then
         echo Run pre backup script | tee -a $log_file
         export log_file my_dir # Variables I require in my pre backup script
         sh -c "${PRE_BACKUP_SCRIPT}"
-        exitcode = ${PIPESTATUS[0]}
+        exitcode=${PIPESTATUS[0]}
     else
         echo Pre backup script defined, but file not found | tee -a $log_file
         # Command not found exit code (https://tldp.org/LDP/abs/html/exitcodes.html)
-        exitcode = 127
+        exitcode=127
     fi
 fi
 

--- a/root/app/backup.sh
+++ b/root/app/backup.sh
@@ -28,6 +28,9 @@ if [[ ! -z ${PRE_BACKUP_SCRIPT} ]]; then
         # Command not found exit code (https://tldp.org/LDP/abs/html/exitcodes.html)
         exitcode=127
     fi
+else
+    # No pre backup script so call it a success
+    exitcode=0
 fi
 
 if [ $exitcode -eq 0 ]; then


### PR DESCRIPTION
I've added a small feature to run a pre-backup script before running the duplicacy backup. I don't have it prevent the backup from running upon failure, but could add that. My use case for this was to be able to mount a ZFS snapshot (the latest one for a dataset) to a fixed mount point before running duplicacy on that mount point. That way duplicacy will only see the changes in the latest snapshot and the snapshot will give an immutable snapshot of the filesystem to avoid problems with files changing while duplicacy is backing up. This is helpful for backing up database files without needing to shutdown the DB (part of the pre-snapshot process handles quiescing the DB first).