### PR TITLE
Add protection to make sure multiple backup / prune jobs don't run simultaneously.

### DIFF
--- a/root/app/backup.sh
+++ b/root/app/backup.sh
@@ -15,49 +15,57 @@ fi
 
 echo ========== Run backup job at `date` ========== | tee $log_file
 
-"$my_dir/delay.sh" $log_file
-
-start=$(date +%s.%N)
-
-if [[ ! -z ${PRE_BACKUP_SCRIPT} ]]; then
-    if [[ -f ${PRE_BACKUP_SCRIPT} ]]; then
-        echo Run pre backup script | tee -a $log_file
-        export log_file my_dir # Variables I require in my pre backup script
-        sh -c "${PRE_BACKUP_SCRIPT}" | tee -a $log_file
-        exitcode=${PIPESTATUS[0]}
-    else
-        echo Pre backup script defined, but file not found | tee -a $log_file
-        # Command not found exit code (https://tldp.org/LDP/abs/html/exitcodes.html)
-        exitcode=127
-    fi
+if operation_in_progress backup; then
+    duration=0
+    exitcode=127
 else
-    # No pre backup script so call it a success
-    exitcode=0
-fi
+    # Use the scripts pid as the pid for simplicity
+    create_backup_pid_file ${$}
+    trap remove_backup_pid_file EXIT
 
-if [ $exitcode -eq 0 ]; then
-    config_dir=/config
+    "$my_dir/delay.sh" $log_file
 
-    cd $config_dir
+    start=$(date +%s.%N)
 
-    nice -n $PRIORITY_LEVEL duplicacy $GLOBAL_OPTIONS backup $BACKUP_OPTIONS | tee -a $log_file
-    exitcode=${PIPESTATUS[0]}
-
-    if [[ ! -z ${POST_BACKUP_SCRIPT} ]]; then
-        if [[ -f ${POST_BACKUP_SCRIPT} ]]; then
-            echo Run post backup script | tee -a $log_file
-            export log_file exitcode duration my_dir # Variables I require in my post backup script
-            sh -c "${POST_BACKUP_SCRIPT}" | tee -a $log_file
+    if [[ ! -z ${PRE_BACKUP_SCRIPT} ]]; then
+        if [[ -f ${PRE_BACKUP_SCRIPT} ]]; then
+            echo Run pre backup script | tee -a $log_file
+            export log_file my_dir # Variables I require in my pre backup script
+            sh -c "${PRE_BACKUP_SCRIPT}" | tee -a $log_file
+            exitcode=${PIPESTATUS[0]}
         else
-            echo Post backup script defined, but file not found | tee -a $log_file
+            echo Pre backup script defined, but file not found | tee -a $log_file
+            # Command not found exit code (https://tldp.org/LDP/abs/html/exitcodes.html)
+            exitcode=127
         fi
+    else
+        # No pre backup script so call it a success
+        exitcode=0
     fi
-else
-    echo Pre backup script FAILED, code $exitcode, | tee -a $log_file
-fi
 
-duration=$(echo "$(date +%s.%N) - $start" | bc)
-subject=""
+    if [ $exitcode -eq 0 ]; then
+        config_dir=/config
+
+        cd $config_dir
+
+        nice -n $PRIORITY_LEVEL duplicacy $GLOBAL_OPTIONS backup $BACKUP_OPTIONS | tee -a $log_file
+        exitcode=${PIPESTATUS[0]}
+
+        if [[ ! -z ${POST_BACKUP_SCRIPT} ]]; then
+            if [[ -f ${POST_BACKUP_SCRIPT} ]]; then
+                echo Run post backup script | tee -a $log_file
+                export log_file exitcode duration my_dir # Variables I require in my post backup script
+                sh -c "${POST_BACKUP_SCRIPT}" | tee -a $log_file
+            else
+                echo Post backup script defined, but file not found | tee -a $log_file
+            fi
+        fi
+    else
+        echo Pre backup script FAILED, code $exitcode, | tee -a $log_file
+    fi
+
+    duration=$(echo "$(date +%s.%N) - $start" | bc)
+fi
 
 if [ $exitcode -eq 0 ]; then
     echo Backup COMPLETED, duration $(converts $duration) | tee -a $log_file

--- a/root/app/common.sh
+++ b/root/app/common.sh
@@ -35,19 +35,23 @@ operation_in_progress()
 
   if [ -f ${backup_pid_file} ]; then
     echo A backup is in progress with PID=$(cat ${backup_pid_file}). Skipping ${operation}. | tee $log_file
-    return 127
+    return 0
   fi
 
   if [ -f ${prune_pid_file} ]; then
     echo A prune is in progress with PID=$(cat ${prune_pid_file}). Skipping ${operation}. | tee $log_file
-    return 127
+    return 0
   fi
+
+  # No operation in progress
+  return 127
 }
 
 create_backup_pid_file()
 {
   # Expect PID as the first parmater
   pid=${1}
+  echo Creating backup pid file, ${backup_pid_file}, with pid=${pid}. | tee $log_file
   echo ${pid} > "${backup_pid_file}"
 }
 
@@ -55,15 +59,18 @@ create_prune_pid_file()
 {
   # Expect PID as the first parmater
   pid=${1}
+  echo Creating prune pid file, ${prune_pid_file}, with pid=$pid}. | tee $log_file
   echo ${pid} > "${prune_pid_file}"
 }
 
 remove_backup_pid_file()
 {
+  echo Removing backup pid file, ${backup_pid_file}. | tee $log_file
   rm "${backup_pid_file}"
 }
 
 remove_prune_pid_file()
 {
+  echo Removing prune pid file, ${prune_pid_file}. | tee $log_file
   rm "${prune_pid_file}"
 }

--- a/root/app/common.sh
+++ b/root/app/common.sh
@@ -24,3 +24,46 @@ if [[ ! -z ${EMAIL_HOSTNAME_ALIAS} ]]; then
 else
     hostname=`hostname`
 fi
+
+backup_pid_file=/var/run/duplicacy_backup.pid
+prune_pid_file=/var/run/duplicacy_prune.pid
+
+operation_in_progress()
+{
+  # Expect the name of the operation as the first parameter
+  operation=${1}
+
+  if [ -f ${backup_pid_file} ]; then
+    echo A backup is in progress with PID=$(cat ${backup_pid_file}). Skipping ${operation}. | tee $log_file
+    return 127
+  fi
+
+  if [ -f ${prune_pid_file} ]; then
+    echo A prune is in progress with PID=$(cat ${prune_pid_file}). Skipping ${operation}. | tee $log_file
+    return 127
+  fi
+}
+
+create_backup_pid_file()
+{
+  # Expect PID as the first parmater
+  pid=${1}
+  echo ${pid} > "${backup_pid_file}"
+}
+
+create_prune_pid_file()
+{
+  # Expect PID as the first parmater
+  pid=${1}
+  echo ${pid} > "${prune_pid_file}"
+}
+
+remove_backup_pid_file()
+{
+  rm "${backup_pid_file}"
+}
+
+remove_prune_pid_file()
+{
+  rm "${prune_pid_file}"
+}


### PR DESCRIPTION
This change adds a check for both the `backup.sh` and `prune.sh` scripts to make sure another backup or prune isn't running before starting a backup or prune. Backups won't run if EITHER a backup or prune is running (and likewise for prune) since a backup and prune running simultaneously can mess up the backup in progress if the backup is very long running (I think > 7 days due to the fossil algorithm used for prunes).

The changes in `backup.sh` and `prune.sh` are fairly small, but look bigger due to indentation. Look at it without whitespace changes in github to see the real changes.