### PR TITLE
Fix: update filters on restart from ENV

### DIFF
--- a/root/usr/bin/container-init-up-20-init.sh
+++ b/root/usr/bin/container-init-up-20-init.sh
@@ -42,7 +42,7 @@ fi
 
 params="$params -pref-dir $config_dir -repository $data_dir $SNAPSHOT_ID $STORAGE_URL"
 
-duplicacy $GLOBAL_OPTIONS init $params
+eval duplicacy $GLOBAL_OPTIONS init $params
 exitcode=$?
 
 if [ $exitcode -ne 0 ]; then

--- a/root/usr/bin/container-init-up-20-init.sh
+++ b/root/usr/bin/container-init-up-20-init.sh
@@ -37,7 +37,11 @@ if [ $exitcode -ne 0 ]; then
     exit $exitcode
 fi
 
-if [[ ! -f $filters_file ]] && [[ -n "${FILTER_PATTERNS}" ]]; then
+if [[ -n "${FILTER_PATTERNS}" ]]; then
+    if [[ -f $filters_file ]]; then
+        rm -f $filters_file
+    fi
+    
     IFS=';'
     read -ra filters <<< "$FILTER_PATTERNS"
     for filter in "${filters[@]}"; do

--- a/root/usr/bin/container-init-up-20-init.sh
+++ b/root/usr/bin/container-init-up-20-init.sh
@@ -8,6 +8,18 @@ config_dir=/config
 data_dir=/data
 filters_file=$config_dir/filters
 
+if [[ -n "${FILTER_PATTERNS}" ]]; then
+    if [[ -f $filters_file ]]; then
+        rm -f $filters_file
+    fi
+    
+    IFS=';'
+    read -ra filters <<< "$FILTER_PATTERNS"
+    for filter in "${filters[@]}"; do
+        echo "$filter" >> $filters_file
+    done
+fi
+
 if [[ -n ${DUPLICACY_PASSWORD} ]]; then
     params=-e
 fi
@@ -35,18 +47,6 @@ exitcode=$?
 
 if [ $exitcode -ne 0 ]; then
     exit $exitcode
-fi
-
-if [[ -n "${FILTER_PATTERNS}" ]]; then
-    if [[ -f $filters_file ]]; then
-        rm -f $filters_file
-    fi
-    
-    IFS=';'
-    read -ra filters <<< "$FILTER_PATTERNS"
-    for filter in "${filters[@]}"; do
-        echo "$filter" >> $filters_file
-    done
 fi
 
 exit 0

--- a/root/usr/bin/container-init-up-20-init.sh
+++ b/root/usr/bin/container-init-up-20-init.sh
@@ -3,11 +3,6 @@
 config_dir=/config
 cd "$config_dir" || exit 128
 
-if [[ -f .duplicacy ]]; then
-    echo "This folder has already been initialized with duplicacy. Not initializing again"
-    exit 0
-fi
-
 params=""
 config_dir=/config
 data_dir=/data


### PR DESCRIPTION
Fix: #170 

Init check is not necessary because duplicacy itself will do init checks and will output the following if it is already configured:
`The repository /config has already been initialized`

This unlocks the filters file update at each container startup so it will keep updated the configuration with the ENV filters.